### PR TITLE
Set up GitHub Actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,3 +20,13 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Archive test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-report
+        path: build/reports/tests/test/
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-coverage-report
+        path: build/reports/jacoco/test/html/


### PR DESCRIPTION
This uses the "GitHub" wizard for creating a Java/Gradle workflow.

I changed the defaults to run on _all_ `push` and `pull_request` events instead of just those on the `main` branch. I'm guessing that may be important for running checks on development branches, which we definitely want for this project.